### PR TITLE
Fix signs for time sync

### DIFF
--- a/board/pluto/overlay_maia/root/adj_chrony.sh
+++ b/board/pluto/overlay_maia/root/adj_chrony.sh
@@ -10,9 +10,9 @@ sign_correction=$(chronyc tracking | grep Frequency | cut -d ":" -f 2 | cut -d "
 
 echo "High accurate ppm = $ppm +/- $precision $sign_correction"
 if [ "$sign_correction" = "fast" ] ; then
-    xo=$(printf "%.0f" $(echo "scale=25; 40000000*(1-($ppm)/1000000)" | bc))
-else
     xo=$(printf "%.0f" $(echo "scale=25; 40000000*(1+($ppm)/1000000)" | bc))
+else
+    xo=$(printf "%.0f" $(echo "scale=25; 40000000*(1-($ppm)/1000000)" | bc))
 fi        
 echo "Correct $xo"
 echo $xo > /sys/bus/iio/devices/iio:device0/xo_correction


### PR DESCRIPTION
xo_correction accepts the true clock of the xo to adjust the frequencies accordingly. It basically sets the xo frequency. So it makes sense if the clock is fast it means  xo frequency + xo frequency*ppm is the true clock. Opposite is true in case the clock is slow.